### PR TITLE
Update rubyzip gem to address security vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,2 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,7 +219,7 @@ GEM
     ruby-enum (0.7.2)
       i18n
     ruby_dep (1.5.0)
-    rubyzip (1.2.2)
+    rubyzip (1.3.0)
     safe_yaml (1.0.4)
     sass (3.7.3)
       sass-listen (~> 4.0.0)


### PR DESCRIPTION
Closes CVE-2019-16892 